### PR TITLE
Get `color`, `brightness`; Add `toggle`; Add `transitionTime`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ var isUndefined = require('lodash/isUndefined');
 var coapClient = require('./lib/coap-client.js');
 var RSVP = require('rsvp');
 
-var transformRawDeviceData = require('./lib/data-transfomers').transformRawDeviceData;
+var transformRawDeviceData = require('./lib/data-transformers').transformRawDeviceData;
 
-var transformRawGroupData = require('./lib/data-transfomers').transformRawGroupData;
+var transformRawGroupData = require('./lib/data-transformers').transformRawGroupData;
 
 class Tradfri {
   constructor(config) {

--- a/index.js
+++ b/index.js
@@ -179,6 +179,25 @@ class Tradfri {
   }
 
   setDeviceState(deviceId, properties) {
+
+    if (properties.state === 'toggle') {
+      var self = this;
+      var promise = new RSVP.Promise((resolve, reject) => {
+        self.getDevice(deviceId).then((device) => {
+          if (device.on) {
+            properties.state = 'off';
+          } else {
+            properties.state = 'on';
+          }
+          return self.coapClient.operate('device', deviceId, properties);
+        }).catch((err) => {
+          reject(err);
+        });
+      });
+
+      return promise;
+    }
+
     return this.coapClient.operate('device', deviceId, properties);
   }
 
@@ -220,8 +239,27 @@ class Tradfri {
   }
 
   setGroupState(groupId, properties) {
+      if (properties.state === 'toggle') {
+      var self = this;
+      var promise = new RSVP.Promise((resolve, reject) => {
+        self.getGroup(groupId).then((group) => {
+          if (group.on) {
+            properties.state = 'off';
+          } else {
+            properties.state = 'on';
+          }
+          return this.coapClient.operate('group', groupId, properties);
+        }).catch((err) => {
+          reject(err);
+        });
+      });
+
+      return promise;
+    }
+
     return this.coapClient.operate('group', groupId, properties);
   }
+
   static create(config) {
     return new Tradfri(config);
   }

--- a/lib/command-builder/index.js
+++ b/lib/command-builder/index.js
@@ -39,7 +39,17 @@ class CoapCommandBuilder {
         }
 
         if (type === 'device' && !isUndefined(operation.color)) {
-            modifier[5706] = operation.color;
+            let color = operation.color.toLowerCase();
+            switch (color) {
+            case 'focus':    case 'cool':   color = 'f5faf6'; break;
+            case 'everyday': case 'normal': color = 'f1e0b5'; break;
+            case 'relax':    case 'warm':   color = 'efd275'; break;
+            default:
+                if ( ! color.match('/^[0-9a-f]{6}$/'))
+                    color = undefined;
+            }
+
+            if (color) modifier[5706] = color;
         }
 
         if (!isUndefined(operation.brightness)) {

--- a/lib/command-builder/index.js
+++ b/lib/command-builder/index.js
@@ -34,7 +34,11 @@ class CoapCommandBuilder {
             }
         }
 
-        if (!isUndefined(operation.color)) {
+        if (!isUndefined(operation.transitionTime)) {
+            modifier[5712] = operation.transitionTime;
+        }
+
+        if (type === 'device' && !isUndefined(operation.color)) {
             modifier[5706] = operation.color;
         }
 

--- a/lib/data-transformers/index.js
+++ b/lib/data-transformers/index.js
@@ -8,6 +8,8 @@ const transformRawDeviceData = (rawDeviceData) => {
   };
 
   device.on = !!get(rawDeviceData, '3311.[0].5850', 0);
+  device.color = get(rawDeviceData, '3311.[0].5706');
+  device.brightness = get(rawDeviceData, '3311.[0].5851');
 
   return device;
 };
@@ -20,6 +22,7 @@ const transformRawGroupData = (rawGroupData) => {
   };
 
   group.on = !!get(rawGroupData, '5850', 0);
+  group.brightness = get(rawGroupData, '5851');
 
   return group;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-tradfri-argon",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Async Node Module To Control IKEA Tradfri Lights with Node.js Argon (v4.x) support. Refactored version of Marton Papps original - node-tradfri.",
   "main": "index.js",
   "keywords": [
@@ -19,6 +19,10 @@
     "name": "nidayand",
     "email": "pggithub@gothager.se"
   },
+  "contributors": [
+    "Marton Papp <morz@morz.hu> (http://morz.hu)",
+    "Tom Gidden <tom@gidden.net>"
+  ],
   "license": "ISC",
   "dependencies": {
     "lodash": "4.17.4",


### PR DESCRIPTION
Hi!

I've added in the calls to retrieve the device/group color and brightness, as well as reimplementing the setting of `transitionTime` for fades.

I've taken the liberty of bumping the version to `1.0.10`, and adding @morzzz007 and myself as contributors to the package file.

I've tested this with an unaltered `node-red-contrib-tradfri` and it works fine on my home installation: I can now do more of the stuff I was able to do with the old `restapi` hack.

Thanks for your excellent work… I was on the verge of refactoring it myself and writing a direct `node-red-contrib-tradfri`, but you beat me to it!  :wink:

Best regards,
Tom