### PR TITLE
Corrected regex for color code hex

### DIFF
--- a/lib/command-builder/index.js
+++ b/lib/command-builder/index.js
@@ -45,7 +45,7 @@ class CoapCommandBuilder {
             case 'everyday': case 'normal': color = 'f1e0b5'; break;
             case 'relax':    case 'warm':   color = 'efd275'; break;
             default:
-                if ( ! color.match('/^[0-9a-f]{6}$/'))
+                if ( ! color.match(/^[0-9a-f]{6}$/))
                     color = undefined;
             }
 


### PR DESCRIPTION
Regex expressions in JS don't get quoted.
Color setting via hex value works after that change for "TRADFRI bulb E27 CWS opal 600lm"

https://www.w3schools.com/jsref/jsref_match.asp