### PR TITLE
Added list of predefined colors

### DIFF
--- a/lib/command-builder/index.js
+++ b/lib/command-builder/index.js
@@ -24,6 +24,7 @@ class CoapCommandBuilder {
 
     put(type, id, operation) {
         const endpoint = type === 'device' ? 15001 : 15004;
+        var colorMap = {'focus':'f5faf6','cool':'f5faf6','everyday':'f1e0b5','normal':'f1e0b5','relax':'efd275','warm':'efd275','cold sky':'dcf0f8','cool daylight':'eaf6fb','cool white':'f5faf6','sunrise':'f2eccf','warm white':'f1e0b5','warm glow':'efd275','candlelight':'ebb63e','warm amber':'e78834','peach':'e57345','dark peach':'da5d41','saturated red':'dc4b31','pink':'e491af','light pink':'e8bedd','saturated pink':'d9337c','light purple':'c984bb','saturated purple':'8f2686','blue':'4a418a','light blue':'6c83ba','lime':'a9d62b','yellow':'d6e44b'};
 
         const modifier = {};
         if (!isUndefined(operation.state)) {
@@ -40,12 +41,10 @@ class CoapCommandBuilder {
 
         if (type === 'device' && !isUndefined(operation.color)) {
             let color = operation.color.toLowerCase();
-            switch (color) {
-            case 'focus':    case 'cool':   color = 'f5faf6'; break;
-            case 'everyday': case 'normal': color = 'f1e0b5'; break;
-            case 'relax':    case 'warm':   color = 'efd275'; break;
-            default:
-                if ( ! color.match(/^[0-9a-f]{6}$/))
+            if (color in colorMap) {
+                color = colorMap[color];
+            } else {
+                if (!color.match(/^[0-9a-f]{6}$/))
                     color = undefined;
             }
 


### PR DESCRIPTION
Hello,

I've been playing around with TRADFRI bulb E27 CWS opal 600lm and noticed that color cannot be changed to any HEX code. Looks like this bulb comes with 20 predefined colors.
I added the full list for convenience.

Greetings