### PR TITLE
Add last_seen and reachable to transformRawDeviceData

### DIFF
--- a/lib/data-transformers/index.js
+++ b/lib/data-transformers/index.js
@@ -5,6 +5,8 @@ const transformRawDeviceData = (rawDeviceData) => {
     id: get(rawDeviceData, '9003'),
     name: get(rawDeviceData, '9001'),
     type: get(rawDeviceData, '3.1'),
+    last_seen: get(rawDeviceData, '9020'),
+    reachable: get(rawDeviceData, '9019'),
   };
 
   device.on = !!get(rawDeviceData, '3311.[0].5850', 0);


### PR DESCRIPTION
Hi @nidayand,

please consider to merge this commit.

This way the last_seen and reachable properties can be accessed from node-red and can be used to verify whether there is radio link to the target Tradfri bulb. I observed several times that Tradfri hub reports the bulb as ON even if there is no radio link and the last state was OFF.

Thanks!