### PR TITLE
Get on/off state for TRADFRI control outlet

### DIFF
--- a/lib/data-transformers/index.js
+++ b/lib/data-transformers/index.js
@@ -5,13 +5,18 @@ const transformRawDeviceData = (rawDeviceData) => {
     id: get(rawDeviceData, '9003'),
     name: get(rawDeviceData, '9001'),
     type: get(rawDeviceData, '3.1'),
+    type_id: get(rawDeviceData, '5750'),
     last_seen: get(rawDeviceData, '9020'),
     reachable: get(rawDeviceData, '9019'),
   };
 
-  device.on = !!get(rawDeviceData, '3311.[0].5850', 0);
-  device.color = get(rawDeviceData, '3311.[0].5706');
-  device.brightness = get(rawDeviceData, '3311.[0].5851');
+  if(device.type_id === 3) { //TRADFRI control outlet  https://github.com/AlCalzone/node-tradfri-client/blob/master/src/lib/accessory.ts
+    device.on = !!get(rawDeviceData, '3312.[0].5850', 0);
+  } else {
+    device.on = !!get(rawDeviceData, '3311.[0].5850', 0);
+    device.color = get(rawDeviceData, '3311.[0].5706');
+    device.brightness = get(rawDeviceData, '3311.[0].5851');
+  }
 
   return device;
 };


### PR DESCRIPTION
When using getDevices() I got `device.on === false` for my TRADFRI control outlet, both if the outlet was switched on or switched off. After some debugging I found out that the control outlet uses a different path for the device data than lightbulbs. 3312 instead of 3311.

Tested on gateway firmware 1.4.15 and outlet firmware 2.0.019